### PR TITLE
Issues/48 Intro page hidden sections

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,7 @@
+.collapsable-section h2:before {
+    content: "  +  ";
+}
+
+.collapsable-section.open h2:before{
+    content: "  -  ";
+}

--- a/conf.py
+++ b/conf.py
@@ -19,6 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
+from docutils import nodes
 project = 'ContinualAI Wiki'
 copyright = '2018-2021, ContinualAI'
 author = ''
@@ -86,8 +87,8 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 html_theme_options = {
-	#"vcs_pageview_mode": ''
-	'logo_only': True,
+    # "vcs_pageview_mode": ''
+    'logo_only': True,
     'analytics_id': 'UA-165355374-1'
 }
 
@@ -189,7 +190,7 @@ epub_title = project
 epub_exclude_files = ['search.html']
 
 # this below is useful to have hmtl inline in rsts
-from docutils import nodes
+
 
 def generate_rawrole(format):
     def role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
@@ -207,3 +208,4 @@ def on_builder_inited(app):
 def setup(app):
     app.add_config_value('rawrole_formats', ['html', 'latex'], 'env')
     app.connect('builder-inited', on_builder_inited)
+    app.add_css_file('custom.css')

--- a/introduction.rst
+++ b/introduction.rst
@@ -97,16 +97,19 @@ Associative pairs require repeated reinforcement to persist. If an organism lear
 
 
 
+
 .. raw:: html
 
     <script>
+    //Toggle sections on click
+
     $(document).ready(function() {
         $(".collapsable-section-body").hide();
         $(".collapsable-section").children().not(".collapsable-section-body").click(function() {
-            if($(this).className != "collapsable-section-body"){
-                $(this).parent().children(".collapsable-section-body").toggle(400);
-                $(this).parent().children(".header").toggleClass("open"); 
-            }
+            $(".collapsable-section-body").not($(this).parent().children(".collapsable-section-body")).hide(400);
+            $(this).parent().children(".collapsable-section-body").toggle(400);
+            $(this).parent().children(".header").toggleClass("open"); 
+            
         })
     });
     </script>

--- a/introduction.rst
+++ b/introduction.rst
@@ -108,8 +108,8 @@ Associative pairs require repeated reinforcement to persist. If an organism lear
         $(".collapsable-section").children().not(".collapsable-section-body").click(function() {
             $(".collapsable-section-body").not($(this).parent().children(".collapsable-section-body")).hide(400);
             $(this).parent().children(".collapsable-section-body").toggle(400);
-            $(this).parent().children(".header").toggleClass("open"); 
-            
+            $(this).parent().toggleClass("open"); 
+            $(".collapsable-section").not($(this).parent()).removeClass("open");
         })
     });
     </script>

--- a/introduction.rst
+++ b/introduction.rst
@@ -104,10 +104,10 @@ Associative pairs require repeated reinforcement to persist. If an organism lear
     //Toggle sections on click
 
     $(document).ready(function() {
-        $(".collapsable-section-body").hide();
+        $(".collapsable-section").children().not("h2").hide();
         $(".collapsable-section").children().not(".collapsable-section-body").click(function() {
-            $(".collapsable-section-body").not($(this).parent().children(".collapsable-section-body")).hide(400);
-            $(this).parent().children(".collapsable-section-body").toggle(400);
+            $(".collapsable-section").children().not("h2").not($(this).parent().children().not("h2")).hide(400);
+            $(this).parent().children().not("h2").toggle(400);
             $(this).parent().toggleClass("open"); 
             $(".collapsable-section").not($(this).parent()).removeClass("open");
         })

--- a/introduction.rst
+++ b/introduction.rst
@@ -3,59 +3,77 @@ Introduction
 
 Here, you will find an *informal* introduction to Continual Learning. For a comprehensive overview of the field, have a look at our `research section <https://wiki.continualai.org/research.html#publications>`_, in which you can find in-depth surveys on the topic together with specific approaches and techniques to address the Continual Learning challenge.
 
+.. rst-class:: collapsable-section
+
 What is Continual/Lifelong Learning?
 ---------------------------------------
 
-Continual Learning (CL), also known as Lifelong learning, is built on the idea of learning continuously about the external world in order to enable the autonomous, incremental development of ever more complex skills and knowledge.
+.. rst-class:: collapsable-section-body
 
-A Continual learning system can be defined as *an adaptive algorithm capable of learning from a continuous stream of information, with such information becoming progressively available over time and where the number of tasks to be learned (e.g. membership classes in a classification task) are not predefined. Critically, the accommodation of new information should occur without catastrophic forgetting or interference* [#f1]_ .
+    Continual Learning (CL), also known as Lifelong learning, is built on the idea of learning continuously about the external world in order to enable the autonomous, incremental development of ever more complex skills and knowledge.
 
-Hence, in the CL scenario, a learning model is required to incrementally build and dynamically update internal representations as the distribution of tasks dynamically changes across its lifetime. Ideally, part of such internal representations will be general and invariant enough to be reusable across similar tasks, while another part should preserve and encode task-specific representations.
+    A Continual learning system can be defined as *an adaptive algorithm capable of learning from a continuous stream of information, with such information becoming progressively available over time and where the number of tasks to be learned (e.g. membership classes in a classification task) are not predefined. Critically, the accommodation of new information should occur without catastrophic forgetting or interference* [#f1]_ .
 
+    Hence, in the CL scenario, a learning model is required to incrementally build and dynamically update internal representations as the distribution of tasks dynamically changes across its lifetime. Ideally, part of such internal representations will be general and invariant enough to be reusable across similar tasks, while another part should preserve and encode task-specific representations.
+
+.. rst-class:: collapsable-section
 
 The Deep Learning approach to learning
----------------------------------------
-Deep Learning (DL) is a subset of Machine Learning (ML) in which models - artificial neural networks, in most of the cases - learn to map input to output by building an adaptive, internal hierarchical representation. Artificial neural networks are made by units linked together by weighted connections. The learning process is defined by changing the value of the weights in order to minimize a cost function which measures how much the output produced by the model differs from the expected outcome. 
+--------------------------------------
 
-Such learning process is adaptive, meaning that it only requires a (possibly large) set of data from which to learn and a suitable cost function to specify the type of task to be performed. 
+.. rst-class:: collapsable-section-body
 
-Decades of research showed that DL models are able to accomplish a range of different tasks, often surpassing human-level performance. They are widespread in several fields like language translation, self-driving cars, bio-medical applications, stock prediction in finance``...`` just to name a few! 
+    Deep Learning (DL) is a subset of Machine Learning (ML) in which models - artificial neural networks, in most of the cases - learn to map input to output by building an adaptive, internal hierarchical representation. Artificial neural networks are made by units linked together by weighted connections. The learning process is defined by changing the value of the weights in order to minimize a cost function which measures how much the output produced by the model differs from the expected outcome.
 
-The astonishing accomplishments made by DL are confined to a specific task: without additional training, a DL neural network which is able to beat the (human) world champion at the game of Go will not be able to drive a car or to translate from English to French. However, nothing prevents us from continuing to train the network on new tasks.
- 
-What will be the behavior of the network at the end of the new learning phase?
-This question is at the heart of the Continual Learning field.
+    Such learning process is adaptive, meaning that it only requires a (possibly large) set of data from which to learn and a suitable cost function to specify the type of task to be performed.
 
+    Decades of research showed that DL models are able to accomplish a range of different tasks, often surpassing human-level performance. They are widespread in several fields like language translation, self-driving cars, bio-medical applications, stock prediction in finance``…`` just to name a few!
+
+    The astonishing accomplishments made by DL are confined to a specific task: without additional training, a DL neural network which is able to beat the (human) world champion at the game of Go will not be able to drive a car or to translate from English to French. However, nothing prevents us from continuing to train the network on new tasks.
+
+    What will be the behavior of the network at the end of the new learning phase? This question is at the heart of the Continual Learning field.
+
+.. rst-class:: collapsable-section
 
 The Catastrophic Forgetting phenomenon
 ---------------------------------------
-When learning in a CL environment, the model is exposed to a streaming of inputs coming from different distributions, representing different tasks. At each learning step, the model will have to adapt in order to meet the expected behavior.
 
-A well-known problem in learning multiple tasks sequentially is the *catastrophic forgetting* (CF) phenomenon, which can be concisely summarized in one sentence: * the process of learning new knowledge quickly disrupts previously acquired information*.
-The catastrophic forgetting (or simply forgetting) is the main problem faced by CL strategies.
+.. rst-class:: collapsable-section-body
 
-Unfortunately, *all* connectionist models are subject to CF. The consequence being that neural networks are not suitable to learning in CL environments, since their performance on previous tasks will degrade very quickly.
+    When learning in a CL environment, the model is exposed to a streaming of inputs coming from different distributions, representing different tasks. At each learning step, the model will have to adapt in order to meet the expected behavior.
 
-CF can be characterized by looking at the *stability-plasticity* dilemma: a learning model has to be plastic enough to learn new information, but it has also to be stable to preserve internal knowledge. 
-This tradeoff is never satisfied for traditional neural networks, where the plasticity easily overpowers the stability.
+    A well-known problem in learning multiple tasks sequentially is the *catastrophic forgetting* (CF) phenomenon, which can be concisely summarized in one sentence: * the process of learning new knowledge quickly disrupts previously acquired information*.
+    The catastrophic forgetting (or simply forgetting) is the main problem faced by CL strategies.
 
+    Unfortunately, *all* connectionist models are subject to CF. The consequence being that neural networks are not suitable to learning in CL environments, since their performance on previous tasks will degrade very quickly.
+
+    CF can be characterized by looking at the *stability-plasticity* dilemma: a learning model has to be plastic enough to learn new information, but it has also to be stable to preserve internal knowledge. 
+    This tradeoff is never satisfied for traditional neural networks, where the plasticity easily overpowers the stability.
+
+.. rst-class:: collapsable-section
 
 Beyond forgetting
 ---------------------------------------
-Even if CF is the main focus of CL, there are other aspects that need to be considered when learning continuously.
 
-Preserving old knowledge is important not only to perform well on previous tasks. It can also be used to perform better on incoming tasks. This feature, called *transfer learning*, enables CL algorithm to require only few examples of a new tasks to master it.
+.. rst-class:: collapsable-section-body
 
-Another interesting opportunity when learning sequentially is the benefit that a previously learned task can receive from subsequently learning new knowledge. Such *backward transfer* can positively affect the performance of a CL algorithm on previuos tasks, without seeing any further examples from it.
-It is needless to say that, without a method that properly mitigate forgetting, no backward transfer is possible.
+    Even if CF is the main focus of CL, there are other aspects that need to be considered when learning continuously.
 
+    Preserving old knowledge is important not only to perform well on previous tasks. It can also be used to perform better on incoming tasks. This feature, called *transfer learning*, enables CL algorithm to require only few examples of a new tasks to master it.
+
+    Another interesting opportunity when learning sequentially is the benefit that a previously learned task can receive from subsequently learning new knowledge. Such *backward transfer* can positively affect the performance of a CL algorithm on previuos tasks, without seeing any further examples from it.
+    It is needless to say that, without a method that properly mitigate forgetting, no backward transfer is possible.
+
+.. rst-class:: collapsable-section
 
 Biological Perspective
 ---------------------------------------
 
-The main evolutionary advantage of learning is to rapidly change an organism’s behavior to succeed in a dynamic environment. These experience-driven alterations occur in much shorter timescales than genetic evolution can adapt to, allowing a single organism to persist in more situations than those whose behavior is fixed. Because of this, experience driven alterations are pervasive throughout the animal kingdom, from complex vertebrates to single celled organisms. The reason for this is simple: learned responses or acquired information from experiences help the chances of an organism’s success as opposed to a randomly selected behavior.
+.. rst-class:: collapsable-section-body
 
-While some learning occurs only once, such as imprinting in ducklings, a majority occurs continuously throughout an organism’s lifespan. As the climate, ecological niche, food supply, or other factors alter, an organism may alter its response as well. Moreover, this may occur multiple times throughout an organism’s life. For example, a scavenging animal may learn the location to a food supply, returning multiple times to that location. When the source is exhausted, then the animal must learn to not only to refrain from returning to the location, but also to learn a new source. This sequence may happen multiple times throughout an animals life, a reality of the scarcity of food.
+    The main evolutionary advantage of learning is to rapidly change an organism’s behavior to succeed in a dynamic environment. These experience-driven alterations occur in much shorter timescales than genetic evolution can adapt to, allowing a single organism to persist in more situations than those whose behavior is fixed. Because of this, experience driven alterations are pervasive throughout the animal kingdom, from complex vertebrates to single celled organisms. The reason for this is simple: learned responses or acquired information from experiences help the chances of an organism’s success as opposed to a randomly selected behavior.
+
+    While some learning occurs only once, such as imprinting in ducklings, a majority occurs continuously throughout an organism’s lifespan. As the climate, ecological niche, food supply, or other factors alter, an organism may alter its response as well. Moreover, this may occur multiple times throughout an organism’s life. For example, a scavenging animal may learn the location to a food supply, returning multiple times to that location. When the source is exhausted, then the animal must learn to not only to refrain from returning to the location, but also to learn a new source. This sequence may happen multiple times throughout an animals life, a reality of the scarcity of food.
 
 Simple learning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,3 +94,19 @@ Associative pairs require repeated reinforcement to persist. If an organism lear
 .. rubric:: References
 
 .. [#f1] G. I. Parisi, R. Kemker, J. L. Part, C. Kanan, and S. Wermter, “Continual lifelong learning with neural networks: A review” Neural Networks, vol. 113, pp. 54–71, 2019.
+
+
+
+.. raw:: html
+
+    <script>
+    $(document).ready(function() {
+        $(".collapsable-section-body").hide();
+        $(".collapsable-section").children().not(".collapsable-section-body").click(function() {
+            if($(this).className != "collapsable-section-body"){
+                $(this).parent().children(".collapsable-section-body").toggle(400);
+                $(this).parent().children(".header").toggleClass("open"); 
+            }
+        })
+    });
+    </script>


### PR DESCRIPTION
Changes Introduction page so sections are hidden by default, except for the section titles. If a title is clicked, the body is shown and the other sections are minimized. Click the title again to collapse the section.