### PR TITLE
Adding Course section in tutorials file

### DIFF
--- a/tutorials.rst
+++ b/tutorials.rst
@@ -16,3 +16,9 @@ Tutorials
   - `[Notebook] Open-Source Frameworks for Deep Learning: an Overview <https://github.com/ContinualAI/colab/blob/master/notebooks/intro_to_dl_frameworks.ipynb>`_
   - `[Notebook] A Gentle Introduction to Continual Learning in PyTorch <https://github.com/ContinualAI/colab/blob/master/notebooks/intro_to_continual_learning.ipynb>`_
   - `[Notebook] A simple Example of Continual Learning with Generative Replay <https://github.com/ContinualAI/colab/blob/master/notebooks/intro_to_generative_replay.ipynb>`_
+
+Courses
+================================
+
+- | `Continual Learning: Towards Broad AI <https://sites.google.com/view/ift6760-b2021/course-description?authuser=0>`_
+  | Mila course [Instructor: Irina Rish; Teaching Assistants: Mojtaba Faramarzi and Touraj Laleh]

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -21,4 +21,4 @@ Courses
 ================================
 
 - | `Continual Learning: Towards Broad AI <https://sites.google.com/view/ift6760-b2021/course-description?authuser=0>`_
-  | Mila course [Instructor: Irina Rish; Teaching Assistants: Mojtaba Faramarzi and Touraj Laleh]
+  | Course @ Mila [Instructor: Irina Rish; Teaching Assistants: Mojtaba Faramarzi and Touraj Laleh]


### PR DESCRIPTION
I have added the 'Courses' section in the tutorials file following this issue https://github.com/ContinualAI/wiki/issues/74#issue-793239237