### PR TITLE
Added WMT20 Lifelong Learning for Machine Translation Shared Task

### DIFF
--- a/research.rst
+++ b/research.rst
@@ -424,6 +424,7 @@ In this section we maintain a list of all Robotics papers that can be related to
 
 Conference Workshops
 ----------------------------------
+- `WMT20 Lifelong Learning for Machine Translation Shared Task <http://www.statmt.org/wmt20/lifelong-learning-task.html>`_
 - `Ro-man 2020 Workshop on Lifelong Learning for Long-term Human-Robot Interaction (LL4LHRI) <https://sites.google.com/view/ll4lhri2020/objectives-and-challenges>`_
 - `ICML 2020 Workshop on Lifelong Learning <https://lifelongml.github.io/>`_
 - `CVPR 2020 Workshop on Continual Learning in Computer Vision <https://sites.google.com/view/clvision2020>`_

--- a/research_template.rst
+++ b/research_template.rst
@@ -27,6 +27,7 @@ to add a reference to your paper! Please, remember to follow the (very simple) `
 
 Conference Workshops
 ----------------------------------
+- `WMT20 Lifelong Learning for Machine Translation Shared Task <http://www.statmt.org/wmt20/lifelong-learning-task.html>`_
 - `Ro-man 2020 Workshop on Lifelong Learning for Long-term Human-Robot Interaction (LL4LHRI) <https://sites.google.com/view/ll4lhri2020/objectives-and-challenges>`_
 - `ICML 2020 Workshop on Lifelong Learning <https://lifelongml.github.io/>`_
 - `CVPR 2020 Workshop on Continual Learning in Computer Vision <https://sites.google.com/view/clvision2020>`_


### PR DESCRIPTION
Updated `Conference Workshops` section to include [Lifelong Learning for Machine Translation Shared Task at WMT20 (EMNLP 2020)](http://www.statmt.org/wmt20/lifelong-learning-task.html).